### PR TITLE
Fix clear command not clearing maintenance tasks

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -30,6 +30,7 @@ public class ClearCommand extends Command {
             return new CommandResult(MESSAGE_CONFIRMATION_REQUIRED);
         }
         model.setAddressBook(new AddressBook());
+        model.getMaintenanceTaskList().clearTasks();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/model/task/MaintenanceTaskList.java
+++ b/src/main/java/seedu/address/model/task/MaintenanceTaskList.java
@@ -18,6 +18,11 @@ public class MaintenanceTaskList {
         tasks.add(task);
     }
 
+    /** Removes all tasks from the list. */
+    public void clearTasks() {
+        tasks.clear();
+    }
+
     /**
      * Removes the task at the specified index from the list.
      * @param index The 0-based index of the task to remove.


### PR DESCRIPTION
clear confirm now also clears the maintenance task list, preventing orphaned tasks from remaining after all contractors are removed.