### PR TITLE
Fix report using filtered person list for contractor lookup

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ReportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReportCommand.java
@@ -83,14 +83,13 @@ public class ReportCommand extends Command {
             }
 
             int contractorIdx = contractorIndex - 1;
-            List<Person> personList = model.getFilteredPersonList();
 
             String contractorName;
             String service;
             String tagsString;
 
-            if (contractorIdx < personList.size()) {
-                Person contractor = personList.get(contractorIdx);
+            if (contractorIdx < allPersons.size()) {
+                Person contractor = allPersons.get(contractorIdx);
                 contractorName = contractor.getName().fullName;
                 service = contractor.getService().toString();
                 tagsString = contractor.getTags().stream()


### PR DESCRIPTION
report was using getFilteredPersonList() with an absolute contractor index, causing wrong contractor info when the list was filtered via findc. Now consistently uses the full person list (allPersons).