### PR TITLE
Fix delt blocking deletion of tasks with deleted contractors

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeltCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeltCommand.java
@@ -53,10 +53,9 @@ public class DeltCommand extends Command {
 
         List<Person> allPersons = model.getAddressBook().getPersonList();
         int contractorIdx = taskToDelete.getContractorIndex() - 1;
-        if (contractorIdx < 0 || contractorIdx >= allPersons.size()) {
-            throw new CommandException("Contractor linked to this task no longer exists.");
-        }
-        Person contractor = allPersons.get(contractorIdx);
+        String contractorName = (contractorIdx >= 0 && contractorIdx < allPersons.size())
+                ? allPersons.get(contractorIdx).getName().fullName
+                : "Unknown (deleted)";
 
         taskList.removeTask(targetIndex.getZeroBased());
 
@@ -64,7 +63,7 @@ public class DeltCommand extends Command {
                 .map(tag -> tag.tagName)
                 .collect(java.util.stream.Collectors.joining(", "));
         String taskDisplay = taskToDelete.getFacility() + " on " + taskToDelete.getDate()
-                + " (Contractor: " + contractor.getName().fullName
+                + " (Contractor: " + contractorName
                 + " | Service: " + taskToDelete.getContractorService()
                 + " | Tags: [" + tagsString + "])";
         return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS, taskDisplay));


### PR DESCRIPTION
delt was throwing an error when the assigned contractor no longer exists, making orphaned tasks impossible to clean up. Now allows deletion regardless, showing 'Unknown (deleted)' for the contractor.