### PR TITLE
Fix donet/delt operating on full list when history filter is active

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeltCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeltCommand.java
@@ -11,7 +11,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.task.MaintenanceTask;
-import seedu.address.model.task.MaintenanceTaskList;
 
 /**
  * Delete maintenance task
@@ -37,8 +36,7 @@ public class DeltCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        MaintenanceTaskList taskList = model.getMaintenanceTaskList();
-        List<MaintenanceTask> lastShownList = taskList.getTasks();
+        List<MaintenanceTask> lastShownList = model.getFilteredMaintenanceTaskList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_INDEX);
@@ -58,7 +56,7 @@ public class DeltCommand extends Command {
         }
         Person contractor = allPersons.get(contractorIdx);
 
-        taskList.removeTask(targetIndex.getZeroBased());
+        model.getMaintenanceTaskList().removeTask(taskToDelete);
 
         String tagsString = taskToDelete.getTags().stream()
                 .map(tag -> tag.tagName)

--- a/src/main/java/seedu/address/logic/commands/DonetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DonetCommand.java
@@ -47,7 +47,7 @@ public class DonetCommand extends Command {
         requireNonNull(model);
         assert model != null : "Model should not be null";
 
-        List<MaintenanceTask> taskList = model.getMaintenanceTaskList().getTasks();
+        List<MaintenanceTask> taskList = model.getFilteredMaintenanceTaskList();
 
         if (targetIndex.getZeroBased() >= taskList.size()) {
             logger.warning("Invalid task index: " + targetIndex.getOneBased());

--- a/src/main/java/seedu/address/model/task/MaintenanceTaskList.java
+++ b/src/main/java/seedu/address/model/task/MaintenanceTaskList.java
@@ -28,6 +28,14 @@ public class MaintenanceTaskList {
         tasks.remove(index);
     }
 
+    /**
+     * Removes the given task from the list by reference.
+     * @param task The task to remove.
+     */
+    public void removeTask(MaintenanceTask task) {
+        tasks.remove(task);
+    }
+
     public List<MaintenanceTask> getTasks() {
         return tasks;
     }


### PR DESCRIPTION
donet and delt were using the full unfiltered task list for index resolution, so after 'history f/FACILITY' the visible indices did not match the actual indices used. Both commands now use the filtered task list, and delt removes by object reference instead of raw index.