### PR TITLE
Fix help window clear description

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -303,7 +303,7 @@ Format: `help`
 
 ### Clearing all entries : `clear confirm`
 
-Clears all contractor entries and maintenance tasks from EstateContacts.
+Permanently clears all contractor entries and maintenance tasks from EstateContacts.
 
 Format: `clear confirm`
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -14,7 +14,7 @@ public class ClearCommand extends Command {
     public static final String CONFIRMATION_KEYWORD = "confirm";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
     public static final String MESSAGE_CONFIRMATION_REQUIRED =
-            "WARNING: This will delete ALL contacts permanently!\n"
+            "WARNING: This will delete ALL contacts and tasks permanently!\n"
             + "To confirm, please type: clear confirm";
 
     private final boolean isConfirmed;

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -42,7 +42,7 @@ public class HelpWindow extends UiPart<Stage> {
 
             System commands:
             - help
-            - clear (asks for confirmation)
+            - clear (user to type clear confirm)
             - exit
 
             Full guide:


### PR DESCRIPTION
1) Updated the in-app help menu (HelpWindow.java) to show clear (ask user to type clear confirm) instead of clear (asks for confirmation), which incorrectly implied an interactive two-step prompt.

2) Updated the warning message in ClearCommand.java to explicitly state that both contacts and tasks will be deleted permanently.

3) Updated UserGuide.md to state that the clear operation is permanent, as the original wording did not make this clear.