### PR TITLE
Add constraints section to history command in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -270,6 +270,11 @@ Format: `history f/FACILITY_NAME`
 * Lists all tasks for the specified facility.
 * If no tasks are found, a message will indicate that no maintenance history exists for that facility.
 
+Constraints:
+* The match is case-insensitive. e.g. `history f/sports hall` will match `Sports Hall`.
+* Only exact facility names will be matched. e.g. `history f/Sports` will not match `Sports Hall`.
+* `FACILITY_NAME` cannot be empty.
+
 Examples:
 * `history f/Sports Hall` displays the maintenance history for the "Sports Hall".
 * `history f/Function Room` displays the maintenance history for the "Function Room".


### PR DESCRIPTION
Fixed missing documentation for the history command in the User Guide. The original section did not specify the matching behaviour for f/FACILITY_NAME, leaving users uncertain whether the search was case-sensitive, exact, or partial. Added a Constraints section clarifying that the match is case-insensitive but requires an exact facility name. This aligns the history command documentation with the existing findc command section which already documented similar matching behaviour.