### PR TITLE
Fix name validation format

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,7 +10,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters, spaces, hyphens, periods and "
+            + "forward slash and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,


### PR DESCRIPTION
Fixed overly restrictive name validation in Name.java that only allowed alphanumeric characters and spaces. This caused valid real-world names containing hyphens, periods, and forward slashes to be incorrectly rejected. For example, names like Jean-Francois, John Doe Jr., and Ravi S/O Ramasamy (common in Singapore context) were not accepted. Updated the validation regex and error message in Name.java to allow these additional characters while still rejecting blank names.